### PR TITLE
No assets

### DIFF
--- a/canopy_article.ml
+++ b/canopy_article.ml
@@ -71,13 +71,13 @@ let to_tyxml_tags tags =
       h2 [pcdata "Tags"];
       div ~a:[a_class ["list-group listing"]] [html]]]
 
-let to_atom ({ title; author; abstract; uri; created; updated; tags; content; } as article) =
+let to_atom cache ({ title; author; abstract; uri; created; updated; tags; content; } as article) =
   let text x : Syndic.Atom.text_construct = Syndic.Atom.Text x in
   let summary = match abstract with
     | Some x -> Some (text x)
     | None -> None
   in
-  let root = Canopy_config.((config ()).root) 
+  let root = Canopy_config.root cache
   in
   let categories =
     List.map
@@ -87,7 +87,7 @@ let to_atom ({ title; author; abstract; uri; created; updated; tags; content; } 
   let generate_id { created; _ } =
     let open Uuidm in
     let stamp = Ptime.to_rfc3339 created in
-    let uuid = Canopy_config.((config ()).uuid) in
+    let uuid = Canopy_config.uuid cache in
     let entry_id = to_string (v5 (create (`V5 (ns_dns, stamp))) uuid) in
     Printf.sprintf "urn:uuid:%s" entry_id
     |> Uri.of_string

--- a/canopy_config.ml
+++ b/canopy_config.ml
@@ -1,14 +1,6 @@
-type t = {
-  remote_uri : string;
-  remote_branch : string option;
-  blog_name : string;
-  index_page : string;
-  port : int;
-  push_hook_path: string;
-  tls_port : int option;
-  uuid : string;
-  root : string;
-}
+open Canopy_utils
+
+exception Required_config of string
 
 let decompose_git_url url =
     match String.rindex url '#' with
@@ -21,14 +13,28 @@ let decompose_git_url url =
 let remote_uri () = fst (decompose_git_url (Key_gen.remote ()))
 let remote_branch () = snd (decompose_git_url (Key_gen.remote ()))
 
-let config () = {
-  remote_uri = remote_uri ();
-  remote_branch = remote_branch ();
-  index_page = Key_gen.index ();
-  blog_name = Key_gen.name ();
-  port = Key_gen.port ();
-  push_hook_path = Key_gen.push_hook ();
-  tls_port = Key_gen.tls_port ();
-  uuid = Key_gen.uuid ();
-  root = Key_gen.root ();
-}
+let index_page cache =
+  match KeyMap.find_config_opt cache [".config";"index_page"] with
+    None -> "Index"
+  | Some p -> p
+
+let blog_name cache =
+  match KeyMap.find_config_opt cache [".config";"blog_name"] with
+    None -> "Canopy"
+  | Some n -> n
+
+let uuid cache =
+  match KeyMap.find_config_opt cache [".config";"uuid"] with
+    None -> raise (Required_config "uuid")
+  | Some u -> u
+
+let root cache =
+  match KeyMap.find_config_opt cache [".config";"root"] with
+    None -> "http://localhost"
+  | Some r -> r
+
+let port () = Key_gen.port ()
+
+let push_hook_path () = Key_gen.push_hook ()
+
+let tls_port () = Key_gen.tls_port ()

--- a/canopy_content.ml
+++ b/canopy_content.ml
@@ -44,8 +44,8 @@ let to_tyxml = function
 let to_tyxml_listing_entry = function
   | Markdown m -> Canopy_article.to_tyxml_listing_entry m
 
-let to_atom = function
-  | Markdown m -> Canopy_article.to_atom m
+let to_atom cache = function
+  | Markdown m -> Canopy_article.to_atom cache m
 
 let find_tag tagname = function
   | Markdown m ->
@@ -63,7 +63,7 @@ let updated = function
 
 let tags content_map =
   let module S = Set.Make(String) in
-  let s = KeyMap.fold (
+  let s = KeyMap.fold_articles (
       fun _k v s -> match v with
         | Markdown m ->
           let s' = S.of_list m.Canopy_article.tags in

--- a/canopy_dispatch.ml
+++ b/canopy_dispatch.ml
@@ -7,24 +7,14 @@ type store_ops = {
   last_commit : unit -> Ptime.t Lwt.t ;
 }
 
-module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE) (Disk: V1_LWT.KV_RO)
+module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE)
 = struct
-
-  let read_fs fs path =
-    Disk.size fs path
-    >>= function
-    | `Error (Disk.Unknown_key _) -> Lwt.return_none
-    | `Ok size ->
-      Disk.read fs path 0 (Int64.to_int size)
-      >>= function
-      | `Error (Disk.Unknown_key _) -> Lwt.return_none
-      | `Ok bufs -> Lwt.return_some (Cstruct.copyv bufs)
 
   let moved_permanently uri =
     let headers = Cohttp.Header.init_with "location" (Uri.to_string uri) in
     S.respond ~headers ~status:`Moved_permanently ~body:`Empty ()
 
-  let rec dispatcher config headers console disk store atom cache uri etag updated =
+  let rec dispatcher headers console store atom cache uri etag updated =
     let open Canopy_utils in
     let respond_not_found () =
       S.respond_string ~headers ~status:`Not_found ~body:"Not found" ()
@@ -38,7 +28,7 @@ module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE) (Disk: V1_LWT.KV_RO)
     in
     let respond_html ~headers ~content ~title ~updated =
       store.subkeys [] >>= fun keys ->
-      let body = Canopy_templates.main ~config ~content ~title ~keys in
+      let body = Canopy_templates.main ~cache:(!cache) ~content ~title ~keys in
       let headers = html_headers headers updated in
       respond_if_modified ~headers ~body ~updated
     and respond_update = function
@@ -49,34 +39,28 @@ module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE) (Disk: V1_LWT.KV_RO)
     in
     match Re_str.split (Re_str.regexp "/") (Uri.pct_decode uri) with
     | [] ->
-      dispatcher config headers console disk store atom cache config.Canopy_config.index_page etag updated
-    | "static"::_ ->
-      begin
-        read_fs disk uri >>= function
-        | None -> S.respond_string ~headers ~status:`Not_found ~body:"Not found" ()
-        | Some body ->
-          let headers = static_headers headers uri updated in
-          respond_if_modified ~headers ~body ~updated
-      end
+      let index_page = Canopy_config.index_page !cache in
+      dispatcher headers console store atom cache index_page etag updated
     | "atom" :: [] ->
       atom () >>= fun body ->
       store.last_commit () >>= fun updated ->
       let headers = atom_headers headers updated in
       respond_if_modified ~headers ~body ~updated
-    | uri::[] when uri = config.Canopy_config.push_hook_path ->
+    | uri::[] when uri = Canopy_config.push_hook_path () ->
       store.update () >>= fun l ->
       respond_update l
     | "tags"::[] -> (
       let tags = Canopy_content.tags !cache in
       let content = Canopy_article.to_tyxml_tags tags in
       store.last_commit () >>= fun updated ->
-      respond_html ~headers ~title:config.Canopy_config.blog_name ~content ~updated
+      let title = Canopy_config.blog_name !cache in
+      respond_html ~headers ~title ~content ~updated
       )
     | "tags"::tagname::_ -> (
         let aux _ v l =
           if Canopy_content.find_tag tagname v then (v::l) else l
         in
-        let sorted = KeyMap.fold aux !cache [] |> List.sort Canopy_content.compare in
+        let sorted = KeyMap.fold_articles aux !cache [] |> List.sort Canopy_content.compare in
         match sorted with
         | [] -> respond_not_found ()
         | _ ->
@@ -85,17 +69,18 @@ module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE) (Disk: V1_LWT.KV_RO)
                         |> List.map Canopy_content.to_tyxml_listing_entry
                         |> Canopy_templates.listing
           in
-          respond_html ~headers ~title:config.Canopy_config.blog_name ~content ~updated
+          let title = Canopy_config.blog_name !cache in
+          respond_html ~headers ~title ~content ~updated
       )
     | key ->
       begin
         match KeyMap.find_opt !cache key with
-        | None -> (
-            store.subkeys key >>= fun keys ->
-            if (List.length keys) = 0 then
-              respond_not_found ()
-            else
-              let articles = List.map (KeyMap.find_opt !cache) keys |> list_reduce_opt in
+        | None
+        | Some (`Config _ ) -> (
+            store.subkeys key >>= function
+            | [] -> respond_not_found ()
+            | keys ->
+              let articles = List.map (KeyMap.find_article_opt !cache) keys |> list_reduce_opt in
               match articles with
               | [] -> respond_not_found ()
               | _ -> (
@@ -105,12 +90,16 @@ module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE) (Disk: V1_LWT.KV_RO)
                                 |> List.map Canopy_content.to_tyxml_listing_entry
                                 |> Canopy_templates.listing
                   in
-                  respond_html ~headers ~title:config.Canopy_config.blog_name ~content ~updated
+                  let title = Canopy_config.blog_name !cache in
+                  respond_html ~headers ~title ~content ~updated
                 ))
-        | Some article ->
+        | Some (`Article article) ->
           let title, content = Canopy_content.to_tyxml article in
           let updated = Canopy_content.updated article in
           respond_html ~headers ~title ~content ~updated
+        | Some (`Raw body) ->
+          let headers = static_headers headers uri updated in
+          respond_if_modified ~headers ~body ~updated
       end
 
   let create console dispatch =
@@ -125,12 +114,12 @@ module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE) (Disk: V1_LWT.KV_RO)
            let uri = fn req in
            C.log_s console (Printf.sprintf "redirecting to %s" (Uri.to_string uri)) >>= fun () ->
            moved_permanently uri)
-      | `Dispatch (config, headers, disk, store, atom, content, time) ->
+      | `Dispatch (headers, store, atom, content, time) ->
         (fun _ request _ ->
            let uri = Cohttp.Request.uri request in
            let etag = Cohttp.Header.get Cohttp.Request.(request.headers) "if-none-match" in
            C.log_s console (Printf.sprintf "request %s" (Uri.to_string uri)) >>= fun () ->
-           dispatcher config headers console disk store atom content (Uri.path uri) etag time)
+           dispatcher headers console store atom content (Uri.path uri) etag time)
     in
     S.make ~callback ~conn_closed ()
 

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -51,8 +51,8 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
          Lwt.return (C.log console msg))
 
   let created_updated_ids commit key =
+    new_task () >>= fun t ->
     repo () >>= fun repo ->
-    Store.master task repo >>= fun t  ->
     Store.history (t "Reading history") >>= fun history ->
     let aux commit_id acc =
       Store.of_commit_id (Irmin.Task.none) commit_id repo >>= fun store ->

--- a/canopy_syndic.ml
+++ b/canopy_syndic.ml
@@ -3,20 +3,20 @@ open Lwt.Infix
 open Canopy_utils
 open Canopy_config
 
-let atom config last_commit_date content_cache =
+let atom last_commit_date content_cache =
   let cache = ref None in
   let update_atom () =
-    let l = KeyMap.fold (fun _ x acc -> x :: acc) !content_cache []
+    let l = KeyMap.fold_articles (fun _ x acc -> x :: acc) !content_cache []
             |> List.sort Canopy_content.compare
             |> resize 10 in
-    let entries = List.map Canopy_content.to_atom l in
+    let entries = List.map (Canopy_content.to_atom !content_cache) l in
     let ns_prefix _ = Some "" in
     last_commit_date () >|= fun updated ->
     Syndic.Atom.feed
-      ~id:(Uri.of_string ("urn:uuid:" ^ config.uuid))
-      ~title:(Syndic.Atom.Text config.blog_name : Syndic.Atom.text_construct)
+      ~id:(Uri.of_string ("urn:uuid:" ^ uuid !content_cache))
+      ~title:(Syndic.Atom.Text (blog_name !content_cache): Syndic.Atom.text_construct)
       ~updated
-      ~links:[Syndic.Atom.link ~rel:Syndic.Atom.Self (Uri.of_string (config.root ^ "/atom"))]
+      ~links:[Syndic.Atom.link ~rel:Syndic.Atom.Self (Uri.of_string (root !content_cache ^ "/atom"))]
       entries
     |> fun feed -> Syndic.Atom.to_xml feed
     |> fun x -> Syndic.XML.to_string ~ns_prefix x

--- a/canopy_templates.ml
+++ b/canopy_templates.ml
@@ -17,14 +17,14 @@ let taglist tags =
 
 let links keys =
   let paths = List.map (function
-			 | x::_ -> x
-			 | _ -> assert false
-		       ) keys |> List.sort_uniq (Pervasives.compare) in
+       | x::_ -> x
+       | _ -> assert false
+           ) keys |> List.sort_uniq (Pervasives.compare) in
   let format_link link =
     li [ a ~a:[a_href ("/" ^ link)] [span [pcdata link]]] in
  List.map format_link paths
 
-let main ~config ~content ~title ~keys =
+let main ~cache ~content ~title ~keys =
   let links = links keys in
   let page =
     html
@@ -52,7 +52,7 @@ let main ~config ~content ~title ~keys =
                    span ~a:[a_class ["icon-bar"]][];
                    span ~a:[a_class ["icon-bar"]][]
                  ];
-                 a ~a:[a_class ["navbar-brand"]; a_href ("/" ^ config.index_page)][pcdata config.blog_name]
+                 a ~a:[a_class ["navbar-brand"]; a_href ("/" ^ index_page cache)][pcdata (blog_name cache)]
                ];
                div ~a:[a_class ["collapse navbar-collapse collapse"]] [
                  ul ~a:[a_class ["nav navbar-nav navbar-right"]] links
@@ -72,7 +72,7 @@ let main ~config ~content ~title ~keys =
 
 let listing entries =
   [div ~a:[a_class ["flex-container"]] [
-	 div ~a:[a_class ["list-group listing"]] entries
+   div ~a:[a_class ["list-group listing"]] entries
        ]
   ]
 

--- a/canopy_utils.ml
+++ b/canopy_utils.ml
@@ -49,9 +49,24 @@ module KeyMap = struct
   module M = Map.Make(KeyOrd)
   include M
 
+  let fold_articles f =
+    M.fold (fun k v acc -> match v with
+        | `Article a -> f k a acc
+        | _ -> acc)
+
   let find_opt m k =
     try Some (M.find k m) with
     | Not_found -> None
+
+  let find_article_opt m k =
+    match find_opt m k with
+    | Some (`Article a) -> Some a
+    | _ -> None
+
+  let find_config_opt m k =
+    match find_opt m k with
+    | Some (`Config a) -> Some a
+    | _ -> None
 end
 
 let add_etag_header time headers =

--- a/config.ml
+++ b/config.ml
@@ -1,77 +1,10 @@
 open Mirage
 
-(* Shell commands to run at configure time *)
-type shellconfig = ShellConfig
-let shellconfig = Type ShellConfig
-
-let no_assets_k =
-  let doc = Key.Arg.info ~doc:"Don't compile assets at configure time" [ "no-assets-compilation" ] in
-  Key.(create "no_assets" Arg.(flag ~stage:`Configure doc))
-
-let config_shell = impl @@ object
-    inherit base_configurable
-
-    method configure i =
-      let open Functoria_app.Cmd in
-      let (>>=) = Rresult.(>>=) in
-      let dir = Info.root i in
-
-      run "mkdir -p %s" (dir ^ "/disk/static/js") >>= fun () ->
-      run "mkdir -p %s" (dir ^ "/disk/static/css") >>= fun () ->
-      if Key.get (Info.context i) no_assets_k
-      then Rresult.Ok ()
-      else
-        let npm_query = run "which npm" |> Rresult.R.is_ok in
-        let lessc_query = run "which lessc" |> Rresult.R.is_ok in
-        let browserify_query = run "which browserify" |> Rresult.R.is_ok in
-        if (npm_query && lessc_query && browserify_query) then
-          (Printf.printf "npm, browserify and lessc found… fetching and compiling all assets\n";
-           run "npm install" >>= fun () ->
-           run "browserify assets/js/main.js -o disk/static/js/canopy.js" >>= fun () ->
-           run "lessc assets/less/style.less disk/static/css/style.css --source-map-map-inline --strict-imports" >>= fun () ->
-           run "cp node_modules/bootstrap/dist/css/bootstrap.min.css disk/static/css/bootstrap.min.css" >>= fun () ->
-           run "cp node_modules/highlight.js/styles/grayscale.css disk/static/css/highlight.css" >>= fun () ->
-           Printf.printf "Compressing compiled assets to assets/assets_generated.tar.gz…\n";
-           run "tar -cf assets/assets_generated.tar.gz disk/")
-        else
-          (Printf.printf "npm, browserify and lessc not found… decompressing from assets/assets_generated.tar.gz\n";
-           run "tar -xf assets/assets_generated.tar.gz")
-
-    method clean i = Functoria_app.Cmd.run "rm -rf node_modules disk"
-
-    method module_name = "Functoria_runtime"
-    method name = "shell_config"
-    method ty = shellconfig
-  end
-
-(* disk device *)
-
-let disk =
-  let fs_key = Key.(value @@ kv_ro ()) in
-  let fat_ro dir = generic_kv_ro ~key:fs_key dir in
-  fat_ro "./disk"
-
 (* Command-line options *)
-
-let root_k =
-  let doc = Key.Arg.info ~doc:"Blog URL" ["root"] in
-  Key.(create "root" Arg.(opt string "http://localhost" doc))
-
-let uuid_k =
-  let doc = Key.Arg.info ~doc:"UUID used as atom feed id." ["u"; "uuid"] in
-  Key.(create "uuid" Arg.(required string doc))
-
-let index_k =
-  let doc = Key.Arg.info ~doc:"Index file name in remote." ["i"; "index"] in
-  Key.(create "index" Arg.(opt string "Index" doc))
 
 let tls_port_k =
   let doc = Key.Arg.info ~doc:"Enable TLS (using keys in `tls/`) on given port." ["tls"] in
   Key.(create "tls_port" Arg.(opt (some int) None doc))
-
-let name_k =
-  let doc = Key.Arg.info ~doc:"Blog name." ["n"; "name"] in
-  Key.(create "name" Arg.(opt string "Canopy" doc))
 
 let port_k =
   let doc = Key.Arg.info ~doc:"Socket port." ["p"; "port"] in
@@ -132,30 +65,24 @@ let stack =
 
 let () =
   let keys = Key.([
-      abstract index_k;
-      abstract name_k;
       abstract port_k;
       abstract push_hook_k;
       abstract remote_k;
       abstract tls_port_k;
-      abstract no_assets_k;
-      abstract uuid_k;
-      abstract root_k;
     ])
   in
   register "canopy" [
     foreign
       ~libraries
-      ~deps:[abstract nocrypto; abstract config_shell]
+      ~deps:[abstract nocrypto]
       ~keys
       ~packages
       "Canopy_main.Main"
-      (console @-> stackv4 @-> resolver @-> conduit @-> kv_ro @-> clock @-> kv_ro @-> job)
+      (console @-> stackv4 @-> resolver @-> conduit @-> clock @-> kv_ro @-> job)
     $ default_console
     $ stack
     $ resolver_dns stack
     $ conduit_direct ~tls:true stack
-    $ disk
     $ default_clock
     $ crunch "tls"
   ]


### PR DESCRIPTION
Half the config data is coming from the content repository and is not known at start up.
So, I replaced the config record with function calls against Canopy_config module.

In Canopy_main, I also pull the store before calling Canopy_syndic.atom (because we need the repo config for this)

There is an example repo here: https://github.com/voila/blog-content
It is basically your blog content, but with extra files under .config/ for the uuid, index, etc...
